### PR TITLE
feat: add a workflowtemplate for argo cd sync/wait

### DIFF
--- a/templates/argocd-sync-and-wait/manifests.yaml
+++ b/templates/argocd-sync-and-wait/manifests.yaml
@@ -1,0 +1,72 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: argocd-sync-and-wait
+  annotations:
+    workflows.argoproj.io/description: >-
+      This task syncs (deploys) an Argo CD application and waits for it to be healthy.
+
+      To do so, it requires the address of the Argo CD server and some form of
+      authentication either a username/password or an authentication token.
+    workflows.argoproj.io/icon: 
+    workflows.argoproj.io/maintainer: daniel.c.herman@gmail.com
+    workflows.argoproj.io/tags: argocd
+    workflows.argoproj.io/version: '>= 2.9.0'
+spec:
+  entrypoint: argocd-sync-and-wait
+  templates:
+  - name: argocd-sync-and-wait
+    inputs:
+      parameters:
+      - name: argocd-version
+        value: v1.6.0
+      - name: application-name
+      - name: revision
+        value: HEAD
+      - name: flags
+        value: --
+      - name: argocd-server-address
+      - name: argocd-credentials-secret
+    script:
+      image: argoproj/argocd:{{inputs.parameters.argocd-version}}
+      command: [bash]
+      env:
+        - name: ARGOCD_AUTH_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: "{{inputs.parameters.argocd-credentials-secret}}"
+              key: token
+              optional: true
+        - name: ARGOCD_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: "{{inputs.parameters.argocd-credentials-secret}}"
+              key: username
+              optional: true
+        - name: ARGOCD_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: "{{inputs.parameters.argocd-credentials-secret}}"
+              key: username
+              optional: true
+        - name: ARGOCD_SERVER
+          value: "{{inputs.parameters.argocd-server-address}}"
+      source: |
+        #!/bin/bash
+
+        set -euo pipefail
+
+        if [[ -z $ARGOCD_AUTH_TOKEN ]] && [[ -z "$ARGOCD_USERNAME" || -z "$ARGOCD_PASSWORD" ]]; then
+          echo "Either the ARGOCD_AUTH_TOKEN must be specified, or the ARGOCD_USERNAME/ARGOCD_PASSWORD must be specified."
+          exit 1
+        fi 
+
+        if [ -z $ARGOCD_AUTH_TOKEN ]; then
+          yes | argocd login "$ARGOCD_SERVER" --username=$ARGOCD_USERNAME --password=$ARGOCD_PASSWORD {{inputs.parameters.flags}}
+        fi
+
+        echo "Running as ArgoCD User:"
+        argocd account get-user-info {{inputs.parameters.flags}}
+        
+        argocd app sync {{inputs.parameters.application-name}} --revision {{inputs.parameters.revision}} {{inputs.parameters.flags}}
+        argocd app wait {{inputs.parameters.application-name}} --health {{inputs.parameters.flags}}


### PR DESCRIPTION
Filing this initially as a draft pull request since there's things missing (some of which we'll need to collaborate on since this is an early contribution):

- [ ] README.md.  Should probably add a lint/build step to ensure contributions have them also
- [ ] Tests.  How should they be defined, and how can we/should we run them?  Assuming they're primarily going to be integration tests given that we're defining workflows, so possibly something using k3s/kind on Github Actions?
- [ ] [Fix Make mutating these templates](https://github.com/argoproj-labs/argo-workflows-catalog/issues/1)
- [ ] What should the icon support look like?  This task would definitely use the ArgoCD icon, but currently unsupported I think