### PR TITLE
fix: correct key used for the ARGOCD_PASSWORD env

### DIFF
--- a/templates/argocd-sync-and-wait/manifests.yaml
+++ b/templates/argocd-sync-and-wait/manifests.yaml
@@ -43,7 +43,7 @@ spec:
       - name: ARGOCD_PASSWORD
         valueFrom:
           secretKeyRef:
-            key: username
+            key: password
             name: '{{inputs.parameters.argocd-credentials-secret}}'
             optional: true
       - name: ARGOCD_SERVER


### PR DESCRIPTION
The key used for the ARGOCD_PASSWORD env var is very incorrect, it should be `password`, not `username`.  Copy paste fail, but does indicate the need for some form of testing since this would likely have been caught there