### PR TITLE
chore: implement basic integration testing

### DIFF
--- a/.github/workflows/run-kind-tests.yml
+++ b/.github/workflows/run-kind-tests.yml
@@ -1,0 +1,63 @@
+name: Catalog Integration Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: engineerd/setup-kind@v0.4.0
+      with:
+        version: v0.8.1
+    - name: Run tests
+      run: |
+        kubectl create ns argo
+        kubectl apply -n argo -f https://raw.githubusercontent.com/argoproj/argo/v2.9.4/manifests/quick-start-minimal.yaml
+
+        # Swap the executor to PNS since Kind doesn't have the docker.sock available to it by default it seems
+        kubectl patch configmap/workflow-controller-configmap \
+          -n argo \
+          --type merge \
+          -p '{"data":{"containerRuntimeExecutor":"pns"}}'
+
+        curl -sLO https://github.com/argoproj/argo/releases/download/v2.9.4/argo-linux-amd64
+        chmod +x argo-linux-amd64
+
+        mkdir -p ~/.local/bin
+        mv ./argo-linux-amd64 ~/.local/bin/argo
+
+        export PATH="$PATH:~/.local/bin"
+
+        find templates -type f -name manifests.yaml | while read f; do
+          kubectl apply -n argo -f "$f"
+        done
+
+        failed=0
+        
+        find templates -type f -path "*tests*" -name "*.yaml" | while read f; do
+          echo "Running tests in $f"
+
+          wfname=$(argo submit -n argo -o name "$f")
+
+          argo watch -n argo "$wfname"
+          
+          # Argo wait exits with the status code of the workflow whereas watch does not
+          # so use it to determine pass/fail
+          if ! argo wait -n argo "$wfname"; then
+            # Mark the run as failed but allow the rest of the tests to continue running
+            echo "[FAIL] $f"
+
+            argo logs -n argo "$wfname"
+            failed=1
+          else
+            echo "[PASS] $f"
+          fi
+        done
+
+        exit $failed
+      

--- a/templates/hello-world/tests/run-task.yaml
+++ b/templates/hello-world/tests/run-task.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: workflow-template-hello-world-
+spec:
+  entrypoint: run-test
+  templates:
+  - name: run-test
+    steps:
+      - - name: call-hello-world
+          templateRef:
+            name: hello-world
+            template: argosay
+      - - name: call-assert
+          template: assert
+          arguments:
+            parameters:
+            - name: test-output
+              value: "{{steps.call-hello-world.outputs.result}}"
+
+  - name: assert
+    inputs:
+      parameters:
+        - name: test-output
+    container:
+      image: alpine:latest
+      command: [sh, -c]
+      args:
+        - "[[ '{{inputs.parameters.test-output}}' == 'hello argo!' ]]"
+        


### PR DESCRIPTION
We can use Argo to implement some basic integration testing capabilities where
authors can write argo workflows to validate that their templates work as expected.

The approach taken here is admittedly basic initially, however running the tests in
series should suffice while we have a small number of tasks in the catalog.  Once
the catalog grows, this might need to be revisited to either parallelize tests, or
be a little smarter about only running tests for templates that have changed.

~~Since `docker.sock` is not available in Kind and I haven't figured it out yet, certain workloads will not
be testable at the moment, but this should allow us to get started writing tests for other types of workflows.~~

Since I believe kind uses containerd internally, we need to use the PNS executor (or one of the non-docker ones), however I think testing other workflows should actually be just fine using dind.  Tried it locally using the example from the Argo repo, seems to work.

The output from `watch` is pretty verbose in the logs, so I'm open to changes there, but it seemed nice to include something like that.